### PR TITLE
Fixed `Variable "domain" does not exist`

### DIFF
--- a/Resources/views/Themes/Panel/theme_panel_sections.html.twig
+++ b/Resources/views/Themes/Panel/theme_panel_sections.html.twig
@@ -5,7 +5,7 @@
 
    Copyright (c) RedKite Labs <webmaster@redkite-labs.com>
 
-   For the full copyright and license information, please view the LICENSE
+   For the full copyright and license information, please view the LICENSEd
    file that was distributed with this source code.
 
    For extra documentation and help please visit http://www.redkite-labs.com
@@ -19,7 +19,7 @@
     {% include 'RedKiteCmsBundle:Themes:Panel/theme_skeleton.html.twig' with {'theme_values': values.active_theme} %}
     </div>
     {% else %}
-        <p><b>{{ "Any active theme has been define" | trans([], domain) }}</b></p>
+        <p><b>{{ "Any active theme has been define" | trans([], 'RedKiteCmsBundle', cms_language) }}</b></p>
         <p>Choose the active theme from the right panel</p>
     {% endif %}
 </td>
@@ -34,7 +34,7 @@
         </table>
         </div>
         {% else %}
-          <p><b>{{ "Any other theme is installed at the moment" | trans([], domain) }}</b></p>
+          <p><b>{{ "Any other theme is installed at the moment" | trans([], 'RedKiteCmsBundle', cms_language) }}</b></p>
         {% endif %}
     </div>
 </td>


### PR DESCRIPTION
Fixes for 'backend/en/al_showThemesPanel' with error:

```
Variable "domain" does not exist in RedKiteCmsBundle:Themes:Panel/theme_panel_sections.html.twig at line 37
500 Internal Server Error - Twig_Error_Runtime
```
