### PR TITLE
Remove enable_yui_compressor

### DIFF
--- a/Controller/AlCmsController.php
+++ b/Controller/AlCmsController.php
@@ -49,7 +49,6 @@ class AlCmsController extends BaseFrontendController
 
         $params = array(
             'template' => 'RedKiteCmsBundle:Cms:Welcome/welcome.html.twig',
-            'enable_yui_compressor' => $this->container->getParameter('red_kite_cms.enable_yui_compressor'),
             'templateStylesheets' => null,
             'templateJavascripts' => null,
             'available_blocks' => null,

--- a/Controller/AlCmsElFinderController.php
+++ b/Controller/AlCmsElFinderController.php
@@ -28,9 +28,7 @@ class AlCmsElFinderController extends ContainerAware
 {
     public function showFilesManagerAction()
     {
-        return $this->container->get('templating')->renderResponse('RedKiteCmsBundle:Elfinder:file_manager.html.twig', array(
-            'enable_yui_compressor' => $this->container->getParameter('red_kite_cms.enable_yui_compressor'),
-        ));
+        return $this->container->get('templating')->renderResponse('RedKiteCmsBundle:Elfinder:file_manager.html.twig');
     }
 
     public function connectMediaAction()

--- a/Controller/DeployController.php
+++ b/Controller/DeployController.php
@@ -97,7 +97,6 @@ class DeployController extends Base\BaseController
             "deployController" => $this->container->getParameter('red_kite_cms.deploy_bundle.controller'),
             "webFolderPath" => $this->container->getParameter('red_kite_cms.web_folder_full_path'),
             "websiteUrl" => $this->container->getParameter('red_kite_cms.website_url'),
-            "yuiCompressorEnabled" => $this->container->getParameter('red_kite_cms.enable_yui_compressor'),
             "credits" => $this->container->getParameter('red_kite_cms.love'),
         );
     }

--- a/Controller/ThemePreviewController.php
+++ b/Controller/ThemePreviewController.php
@@ -65,7 +65,6 @@ class ThemePreviewController extends AlCmsController
             'templateJavascripts' => $this->fixAssets($this->pageTree->getExternalJavascripts()),
             'templates' => array_keys($theme->getTemplates()),
             'frontController' => $this->getFrontcontroller(),
-            'enable_yui_compressor' => $this->container->getParameter('red_kite_cms.enable_yui_compressor'),
             'language_name' => $languageName,
             'page_name' => $pageName,
         );

--- a/Core/Deploy/TemplateSection/AssetSection.php
+++ b/Core/Deploy/TemplateSection/AssetSection.php
@@ -42,17 +42,16 @@ class AssetSection extends TemplateSectionTwig
     {
         parent::generateSection($pageTree, $theme, $options);
 
-        $yuiEnabled = $options["yuiCompressorEnabled"];
         $assetsSection = $this->writeComment("Assets section");
-        $assetsSection .= $this->generateExternalStylesheet($yuiEnabled);
-        $assetsSection .= $this->generateExternalJavascripts($yuiEnabled);
+        $assetsSection .= $this->generateExternalStylesheet();
+        $assetsSection .= $this->generateExternalJavascripts();
         $assetsSection .= $this->generateInternalStylesheet();
         $assetsSection .= $this->generateInternalJavascripts();
 
         return $assetsSection;
     }
 
-    private function generateExternalStylesheet($yuiEnabled)
+    private function generateExternalStylesheet()
     {
         $externalStylesheets = $this->pageTree->getExternalStylesheets();
         if (empty($externalStylesheets)) {
@@ -60,12 +59,12 @@ class AssetSection extends TemplateSectionTwig
         }
 
         $sectionContent = '<link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />';
-        $filter = $yuiEnabled ? '?yui_css,cssrewrite' : '?cssrewrite';
+        $filter = 'cssrewrite';
 
         return $this->writeBlock('external_stylesheets', $this->writeAssetic('stylesheets', implode(' ', array_map(function ($value) { return '"' . $value . '"'; }, $externalStylesheets )), $sectionContent, $filter), true);
     }
 
-    private function generateExternalJavascripts($yuiEnabled)
+    private function generateExternalJavascripts()
     {
         $externalJavascripts = $this->pageTree->getExternalJavascripts();
         if (empty($externalJavascripts)) {
@@ -73,9 +72,8 @@ class AssetSection extends TemplateSectionTwig
         }
 
         $sectionContent = '<script src="{{ asset_url }}"></script>';
-        $filter = $yuiEnabled ? '?yui_js' : '';
 
-        return $this->writeBlock('external_javascripts', $this->writeAssetic('javascripts', implode(' ', array_map(function ($value) { return '"' . $value . '"'; }, $externalJavascripts )), $sectionContent, $filter), true);
+        return $this->writeBlock('external_javascripts', $this->writeAssetic('javascripts', implode(' ', array_map(function ($value) { return '"' . $value . '"'; }, $externalJavascripts )), $sectionContent), true);
     }
 
     private function generateInternalStylesheet()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,7 +49,6 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('upload_assets_full_path')->defaultValue('%red_kite_cms.web_folder_full_path%/uploads/assets')->end()
                 ->scalarNode('upload_assets_absolute_path')->defaultValue('/%red_kite_cms.web_folder%/uploads/assets')->end()
                 ->scalarNode('theme_structure_file')->defaultValue('%kernel.root_dir%/Resources/.theme_structure')->end()
-                ->booleanNode('enable_yui_compressor')->defaultFalse()->end()
                 ->scalarNode('love')->defaultValue('yes')->end()
                 ->scalarNode('website_url')->defaultValue('')->end()
                 ->scalarNode('bootstrap_version')->defaultValue('3.x')->end()

--- a/DependencyInjection/RedKiteCmsExtension.php
+++ b/DependencyInjection/RedKiteCmsExtension.php
@@ -49,7 +49,6 @@ class RedKiteCmsExtension extends Extension
         $container->setParameter('red_kite_cms.web_folder_full_path', $config['web_folder_dir_full_path']);
         $container->setParameter('red_kite_cms.upload_assets_dir', $config['upload_assets_dir']);
         $container->setParameter('red_kite_cms.love', $config['love']);
-        $container->setParameter('red_kite_cms.enable_yui_compressor', $config['enable_yui_compressor']);
         $container->setParameter('red_kite_cms.theme_structure_file', $config['theme_structure_file']);
         $container->setParameter('red_kite_cms.website_url', $config['website_url']);
         $container->setParameter('red_kite_cms.bootstrap_version', $config['bootstrap_version']);

--- a/Resources/config/config_rkcms.yml
+++ b/Resources/config/config_rkcms.yml
@@ -49,13 +49,6 @@ assetic:
     bundles: [RedKiteCmsBundle]
     filters:
         cssrewrite: ~
-        yui_css:
-            jar: %kernel.root_dir%/Resources/java/yuicompressor.jar
-        yui_js:
-            jar: %kernel.root_dir%/Resources/java/yuicompressor.jar
-
-red_kite_cms:
-    enable_yui_compressor: true
 
 red_kite_labs_theme_engine:
     render_slot_class: RedKiteLabs\RedKiteCmsBundle\Twig\SlotRendererExtension

--- a/Resources/config/config_rkcms_test.yml
+++ b/Resources/config/config_rkcms_test.yml
@@ -13,5 +13,4 @@ swiftmailer:
     disable_delivery: true
 
 red_kite_cms:
-    enable_yui_compressor: true
     active_theme_file: %kernel.root_dir%/Resources/.tests_active_theme

--- a/Resources/views/Bootstrap/2.x/Security/Login/login-form-ajax.html.twig
+++ b/Resources/views/Bootstrap/2.x/Security/Login/login-form-ajax.html.twig
@@ -16,7 +16,7 @@
 {% extends 'RedKiteCmsBundle:Bootstrap:' ~ bootstrap_version ~ '/base.html.twig' %}
 
 {% block body %}
-    {% stylesheets  filter='?yui_css,cssrewrite' 'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
+    {% stylesheets  filter='cssrewrite' 'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
                                                  'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
                                                  'bundles/redkitecms/css/skins/bootstrap/skin.css' %}
     <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />

--- a/Resources/views/Bootstrap/2.x/Template/Cms/template.html.twig
+++ b/Resources/views/Bootstrap/2.x/Template/Cms/template.html.twig
@@ -16,33 +16,19 @@
 {% extends 'RedKiteCmsBundle:Template:Cms/template.html.twig' %}
 
 {% block external_stylesheets %}
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-        {% stylesheets filter='?yui_css,cssrewrite' 'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
-                                                    'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
-                                                    'components/redkitecms/font-awesome/css/font-awesome.min.css'
-                                                    'bundles/redkitecms/css/skins/bootstrap/skin.css'
-                                                    'bundles/redkitecms/css/skins/bootstrap/skin_2.x.css'
-                                                    'components/redkitecms/jquery-ui/themes/smoothness/*'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
-        %} 
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />
-        {% endstylesheets %}
-    {% else %}
-        {% stylesheets filter='?cssrewrite' 'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
-                                            'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
-                                            'components/redkitecms/font-awesome/css/font-awesome.min.css'
-                                            'bundles/redkitecms/css/skins/bootstrap/skin.css'
-                                            'bundles/redkitecms/css/skins/bootstrap/skin_2.x.css'
-                                            'components/redkitecms/jquery-ui/themes/smoothness/*'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
-        %}
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
-        {% endstylesheets %}
-    {% endif %}
+    {% stylesheets filter='cssrewrite'
+        'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
+        'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
+        'components/redkitecms/font-awesome/css/font-awesome.min.css'
+        'bundles/redkitecms/css/skins/bootstrap/skin.css'
+        'bundles/redkitecms/css/skins/bootstrap/skin_2.x.css'
+        'components/redkitecms/jquery-ui/themes/smoothness/*'
+        'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
+    %}
+    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
+    {% endstylesheets %}
     
     {% for value in templateStylesheets %} 
     <link href="{{ asset(value) }}" rel="stylesheet" type="text/css" media="all" />
@@ -51,31 +37,18 @@
 
 {% block external_javascripts %}
     <script src="{{ asset('bundles/redkitecms/js/lang/' ~ cms_language ~ '.js') }}"></script>
-    
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-    {% javascripts  filter='?yui_js' 'components/jquery/jquery.min.js'
-                                     'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                                     'components/redkitecms/twitter-bootstrap/2.x/js/bootstrap.min.js'
-                                     'components/jquery-easing/jquery.easing.min.js'
-                                     'components/holderjs/holder.js'
-                                     'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
-                                     'bundles/redkitecms/js/*' 
-    %} 
-    
-    <script src="{{ asset_url }}"></script>
-    {% endjavascripts %}
-    {% else %}
-    {% javascripts  'components/jquery/jquery.min.js'
-                    'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                    'components/redkitecms/twitter-bootstrap/2.x/js/bootstrap.min.js'
-                    'components/jquery-easing/jquery.easing.min.js'
-                    'components/holderjs/holder.js'
-                    'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
-                    'bundles/redkitecms/js/*' 
+
+    {% javascripts
+        'components/jquery/jquery.min.js'
+        'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
+        'components/redkitecms/twitter-bootstrap/2.x/js/bootstrap.min.js'
+        'components/jquery-easing/jquery.easing.min.js'
+        'components/holderjs/holder.js'
+        'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
+        'bundles/redkitecms/js/*'
     %}
     <script src="{{ asset_url }}"></script>
     {% endjavascripts %}
-    {% endif %}
     
     {% for value in templateJavascripts %}
     <script src="{{ asset(value) }}"></script>

--- a/Resources/views/Bootstrap/2.x/Template/Preview/template.html.twig
+++ b/Resources/views/Bootstrap/2.x/Template/Preview/template.html.twig
@@ -16,30 +16,18 @@
 {% extends 'RedKiteCmsBundle:Template:Preview/template.html.twig' %}
 
 {% block external_stylesheets %}
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-        {% stylesheets filter='?yui_css,cssrewrite' 'components/redkitecms/jquery-ui/themes/smoothness/*'
-                                                    'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
-                                                    'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
-                                                    'bundles/redkitecms/css/skins/bootstrap/skin.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
-        %} 
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />
-        {% endstylesheets %}
-    {% else %}
-        {% stylesheets filter='?cssrewrite' 'components/redkitecms/jquery-ui/themes/smoothness/*'
-                                            'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
-                                            'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
-                                            'bundles/redkitecms/vendor/vendor-adapter.css' 
-                                            'bundles/redkitecms/css/skins/bootstrap/skin.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
-        %}
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
-        {% endstylesheets %}
-    {% endif %}
+    {% stylesheets filter='cssrewrite'
+        'components/redkitecms/jquery-ui/themes/smoothness/*'
+        'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap.min.css'
+        'components/redkitecms/twitter-bootstrap/2.x/css/bootstrap-responsive.min.css'
+        'bundles/redkitecms/vendor/vendor-adapter.css'
+        'bundles/redkitecms/css/skins/bootstrap/skin.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
+    %}
+    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
+    {% endstylesheets %}
     
     {% for value in templateStylesheets %} 
     <link href="{{ asset(value) }}" rel="stylesheet" type="text/css" media="all" />
@@ -48,31 +36,18 @@
 
 {% block external_javascripts %}
     <script src="{{ asset('bundles/redkitecms/js/lang/' ~ cms_language ~ '.js') }}"></script>
-    
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-    {% javascripts  filter='?yui_js' 'components/jquery/jquery.min.js'
-                                     'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                                     'components/redkitecms/twitter-bootstrap/2.x/js/bootstrap.js'
-                                     'components/jquery-easing/jquery.easing.min.js'
-                                     'components/holderjs/holder.js'
-                                     'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
-                                     'bundles/redkitecms/js/*' 
-    %} 
-    
-    <script src="{{ asset_url }}"></script>
-    {% endjavascripts %}
-    {% else %}
-    {% javascripts  'components/jquery/jquery.min.js'
-                    'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                    'components/redkitecms/twitter-bootstrap/2.x/js/bootstrap.min.js'
-                    'components/jquery-easing/jquery.easing.min.js'
-                    'components/holderjs/holder.js'
-                    'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
-                    'bundles/redkitecms/js/*' 
+
+    {% javascripts
+        'components/jquery/jquery.min.js'
+        'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
+        'components/redkitecms/twitter-bootstrap/2.x/js/bootstrap.min.js'
+        'components/jquery-easing/jquery.easing.min.js'
+        'components/holderjs/holder.js'
+        'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
+        'bundles/redkitecms/js/*'
     %}
     <script src="{{ asset_url }}"></script>
     {% endjavascripts %}
-    {% endif %}
     
     {% for value in templateJavascripts %}
     <script src="{{ asset(value) }}"></script>

--- a/Resources/views/Bootstrap/3.x/Security/Login/login-form-ajax.html.twig
+++ b/Resources/views/Bootstrap/3.x/Security/Login/login-form-ajax.html.twig
@@ -16,7 +16,7 @@
 {% extends 'RedKiteCmsBundle:Bootstrap:' ~ bootstrap_version ~ '/base.html.twig' %}
 
 {% block body %}
-    {% stylesheets  filter='?yui_css,cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
+    {% stylesheets  filter='cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
                                                  'bundles/redkitecms/css/skins/bootstrap/skin.css' %}
     <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />
     {% endstylesheets %}

--- a/Resources/views/Bootstrap/3.x/Template/Cms/template.html.twig
+++ b/Resources/views/Bootstrap/3.x/Template/Cms/template.html.twig
@@ -16,31 +16,18 @@
 {% extends 'RedKiteCmsBundle:Template:Cms/template.html.twig' %}
 
 {% block external_stylesheets %}
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-        {% stylesheets filter='?yui_css,cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
-                                                    'components/redkitecms/font-awesome/css/font-awesome.min.css'
-                                                    'bundles/redkitecms/css/skins/bootstrap/skin.css'
-                                                    'bundles/redkitecms/css/skins/bootstrap/skin_3.x.css'
-                                                    'components/redkitecms/jquery-ui/themes/smoothness/*'   
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
-                                                    'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
-        %} 
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />
-        {% endstylesheets %}
-    {% else %}
-        {% stylesheets filter='?cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
-                                            'components/redkitecms/font-awesome/css/font-awesome.min.css'
-                                            'bundles/redkitecms/css/skins/bootstrap/skin.css'
-                                            'bundles/redkitecms/css/skins/bootstrap/skin_3.x.css'
-                                            'components/redkitecms/jquery-ui/themes/smoothness/*'   
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
-                                            'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
-        %}
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
-        {% endstylesheets %}
-    {% endif %}
+    {% stylesheets filter='cssrewrite'
+        'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
+        'components/redkitecms/font-awesome/css/font-awesome.min.css'
+        'bundles/redkitecms/css/skins/bootstrap/skin.css'
+        'bundles/redkitecms/css/skins/bootstrap/skin_3.x.css'
+        'components/redkitecms/jquery-ui/themes/smoothness/*'
+        'bundles/redkitelabselfinder/vendor/ElFinder/vendor/jquery-ui.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/css/elfinder.min.css'
+        'bundles/redkitelabselfinder/vendor/ElFinder/css/theme.css'
+    %}
+    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
+    {% endstylesheets %}
     
     {% for value in templateStylesheets %} 
     <link href="{{ asset(value) }}" rel="stylesheet" type="text/css" media="all" />
@@ -49,31 +36,18 @@
 
 {% block external_javascripts %}
     <script src="{{ asset('bundles/redkitecms/js/lang/' ~ cms_language ~ '.js') }}"></script>
-    
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-    {% javascripts  filter='?yui_js' 'components/jquery/jquery.min.js'
-                                     'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                                     'components/redkitecms/twitter-bootstrap/3.x/js/bootstrap.js'
-                                     'components/jquery-easing/jquery.easing.min.js'
-                                     'components/holderjs/holder.js'
-                                     'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
-                                     'bundles/redkitecms/js/*' 
-    %} 
-    
-    <script src="{{ asset_url }}"></script>
-    {% endjavascripts %}
-    {% else %}
-    {% javascripts  'components/jquery/jquery.min.js'
-                    'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                    'components/redkitecms/twitter-bootstrap/3.x/js/bootstrap.min.js'
-                    'components/jquery-easing/jquery.easing.min.js'
-                    'components/holderjs/holder.js'
-                    'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
-                    'bundles/redkitecms/js/*' 
+
+    {% javascripts
+        'components/jquery/jquery.min.js'
+        'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
+        'components/redkitecms/twitter-bootstrap/3.x/js/bootstrap.min.js'
+        'components/jquery-easing/jquery.easing.min.js'
+        'components/holderjs/holder.js'
+        'bundles/redkitelabselfinder/vendor/ElFinder/js/elfinder.min.js'
+        'bundles/redkitecms/js/*'
     %}
     <script src="{{ asset_url }}"></script>
     {% endjavascripts %}
-    {% endif %}
     
     {% for value in templateJavascripts %}
     <script src="{{ asset(value) }}"></script>

--- a/Resources/views/Bootstrap/3.x/Template/Preview/template.html.twig
+++ b/Resources/views/Bootstrap/3.x/Template/Preview/template.html.twig
@@ -22,44 +22,25 @@
     <link href="{{ asset(value) }}" rel="stylesheet" type="text/css" media="all" />
     {% endfor %}
 
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-        {% stylesheets filter='?yui_css,cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
-                                                    'bundles/redkitecms/vendor/vendor-adapter.css' 
-                                                    'bundles/redkitecms/css/skins/bootstrap/skin.css'
-        %}
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />
-        {% endstylesheets %}
-    {% else %}
-        {% stylesheets filter='?cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
-                                            'bundles/redkitecms/vendor/vendor-adapter.css' 
-                                            'bundles/redkitecms/css/skins/bootstrap/skin.css'
-        %}
-        <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
-        {% endstylesheets %}
-    {% endif %}
+    {% stylesheets filter='cssrewrite'
+        'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
+        'bundles/redkitecms/vendor/vendor-adapter.css'
+        'bundles/redkitecms/css/skins/bootstrap/skin.css'
+    %}
+    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="screen" />
+    {% endstylesheets %}
 {% endblock %}
 
 {% block external_javascripts %}
-    {% if enable_yui_compressor is defined and enable_yui_compressor %}
-    {% javascripts  filter='?yui_js' 'components/jquery/jquery.min.js'
-                                     'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                                     'components/redkitecms/twitter-bootstrap/3.x/js/bootstrap.js'
-                                     'components/jquery-easing/jquery.easing.min.js'
-                                     'components/holderjs/holder.js'
-    %} 
-    
-    <script src="{{ asset_url }}"></script>
-    {% endjavascripts %}
-    {% else %}
-    {% javascripts  'components/jquery/jquery.min.js'
-                    'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
-                    'components/redkitecms/twitter-bootstrap/3.x/js/bootstrap.js'
-                    'components/jquery-easing/jquery.easing.min.js'
-                    'components/holderjs/holder.js'
+    {% javascripts
+        'components/jquery/jquery.min.js'
+        'components/redkitecms/jquery-ui/js/jquery-ui.min.js'
+        'components/redkitecms/twitter-bootstrap/3.x/js/bootstrap.js'
+        'components/jquery-easing/jquery.easing.min.js'
+        'components/holderjs/holder.js'
     %}
     <script src="{{ asset_url }}"></script>
     {% endjavascripts %}
-    {% endif %}
     
     {% for value in templateJavascripts %}
     <script src="{{ asset(value) }}"></script>

--- a/Resources/views/Security/Login/login-form.html.twig
+++ b/Resources/views/Security/Login/login-form.html.twig
@@ -16,7 +16,7 @@
 {% extends 'RedKiteLabsThemeEngineBundle:Frontend:base.html.twig' %}
 
 {% block external_stylesheets %}
-    {% stylesheets  filter='?yui_css,cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
+    {% stylesheets  filter='cssrewrite' 'components/redkitecms/twitter-bootstrap/3.x/css/bootstrap.min.css'
                                                  'bundles/redkitecms/css/skins/bootstrap/skin.css' %}
     <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />
     {% endstylesheets %}

--- a/Tests/Functional/app/config/config.yml
+++ b/Tests/Functional/app/config/config.yml
@@ -30,13 +30,6 @@ assetic:
     debug:          %kernel.debug%
     use_controller: false
     bundles:        [ ]
-    #java: /usr/bin/java
-    filters:
-        cssrewrite: ~
-        yui_css:
-            jar: %kernel.root_dir%/Resources/java/yuicompressor.jar
-        yui_js:
-            jar: %kernel.root_dir%/Resources/java/yuicompressor.jar
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/Tests/Functional/app/config/config_rkcms_test.yml
+++ b/Tests/Functional/app/config/config_rkcms_test.yml
@@ -30,7 +30,6 @@ red_kite_labs_bootstrap:
     vendor_dir: "%kernel.root_dir%/../../../vendor"
 
 red_kite_cms:
-    enable_yui_compressor: true
     active_theme_file: %kernel.root_dir%/Resources/.tests_active_theme
 
 red_kite_labs_theme_engine:

--- a/Tests/Unit/Controller/AlCmsElFinderControllerTest.php
+++ b/Tests/Unit/Controller/AlCmsElFinderControllerTest.php
@@ -44,22 +44,13 @@ class AlCmsElFinderControllerTest extends TestCase
         $templating = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\EngineInterface');        
         $templating->expects($this->once())
             ->method('renderResponse')
-            ->with('RedKiteCmsBundle:Elfinder:file_manager.html.twig', 
-                    array(
-                        'enable_yui_compressor' => true,
-                    )
-            )
+            ->with('RedKiteCmsBundle:Elfinder:file_manager.html.twig')
         ;
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container->expects($this->at(0))
              ->method('get')
              ->with('templating')
              ->will($this->returnValue($templating));
-        
-        $container->expects($this->at(1))
-             ->method('getParameter')
-             ->with('red_kite_cms.enable_yui_compressor')
-             ->will($this->returnValue(true));
 
         $controller = new AlCmsElFinderController();
         $controller->setContainer($container);

--- a/Tests/Unit/Controller/DeployControllerTest.php
+++ b/Tests/Unit/Controller/DeployControllerTest.php
@@ -256,13 +256,7 @@ class DeployControllerTest extends TestCase
             ->method('getParameter')
             ->with('red_kite_cms.website_url')
         ;
-        
-        $at++;
-        $this->container->expects($this->at($at))
-            ->method('getParameter')
-            ->with('red_kite_cms.enable_yui_compressor')
-        ;
-        
+
         $at++;
         $this->container->expects($this->at($at))
             ->method('getParameter')

--- a/Tests/Unit/Core/Deploy/TemplateSection/AssetSectionTest.php
+++ b/Tests/Unit/Core/Deploy/TemplateSection/AssetSectionTest.php
@@ -31,7 +31,7 @@ class AssetSectionTest extends TestCase
     /**
      * @dataProvider assetsProvider
      */
-    public function testAssets($yuiCompressorEnabled, $expectedResult, $externalStylesheets, $internalStylesheets = "", $externalJavascripts = "", $internalJavascripts = "")
+    public function testAssets($expectedResult, $externalStylesheets, $internalStylesheets = "", $externalJavascripts = "", $internalJavascripts = "")
     {
         $urlManager = $this->getMock("RedKiteLabs\RedKiteCmsBundle\Core\UrlManager\AlUrlManagerInterface");
         $theme = $this->getMockBuilder("RedKiteLabs\ThemeEngineBundle\Core\Theme\AlTheme")
@@ -72,8 +72,7 @@ class AssetSectionTest extends TestCase
         $metatagsSection = new AssetSection($urlManager);
         $options = array(
             "uploadAssetsFullPath" => "",
-            "uploadAssetsAbsolutePath" => "",
-            "yuiCompressorEnabled" => $yuiCompressorEnabled,
+            "uploadAssetsAbsolutePath" => ""
         );
         
         $this->assertEquals($expectedResult, $metatagsSection->generateSection($pageTree, $theme, $options));
@@ -83,66 +82,24 @@ class AssetSectionTest extends TestCase
     {
         return array(
             array(
-                true,
                  PHP_EOL . '{#--------------  ASSETS SECTION  --------------#}' . PHP_EOL,
                 array(),
             ),
             array(
-                true,
                  PHP_EOL . '{#--------------  ASSETS SECTION  --------------#}' . PHP_EOL .
                 '{% block external_stylesheets %}' . PHP_EOL .
                 '{{ parent() }}' . PHP_EOL .
-                '  {% stylesheets "asset.css" filter="?yui_css,cssrewrite" %}' . PHP_EOL .
+                '  {% stylesheets "asset.css" filter="cssrewrite" %}' . PHP_EOL .
                 '    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />' . PHP_EOL .
                 '  {% endstylesheets %}' . PHP_EOL .
                 '{% endblock %}' . PHP_EOL . PHP_EOL,
                 array('asset.css'),
             ),
             array(
-                false,
                  PHP_EOL . '{#--------------  ASSETS SECTION  --------------#}' . PHP_EOL .
                 '{% block external_stylesheets %}' . PHP_EOL .
                 '{{ parent() }}' . PHP_EOL .
-                '  {% stylesheets "asset.css" filter="?cssrewrite" %}' . PHP_EOL .
-                '    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />' . PHP_EOL .
-                '  {% endstylesheets %}' . PHP_EOL .
-                '{% endblock %}' . PHP_EOL . PHP_EOL,
-                array('asset.css'),
-            ),
-            array(
-                true,
-                 PHP_EOL . '{#--------------  ASSETS SECTION  --------------#}' . PHP_EOL .
-                '{% block external_stylesheets %}' . PHP_EOL .
-                '{{ parent() }}' . PHP_EOL .
-                '  {% stylesheets "asset.css" filter="?yui_css,cssrewrite" %}' . PHP_EOL .
-                '    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />' . PHP_EOL .
-                '  {% endstylesheets %}' . PHP_EOL .
-                '{% endblock %}' . PHP_EOL . PHP_EOL .                
-                '{% block external_javascripts %}' . PHP_EOL .
-                '{{ parent() }}' . PHP_EOL .
-                '  {% javascripts "stylesheets.js" filter="?yui_js" %}' . PHP_EOL .
-                '    <script src="{{ asset_url }}"></script>' . PHP_EOL .
-                '  {% endjavascripts %}' . PHP_EOL .
-                '{% endblock %}' . PHP_EOL . PHP_EOL .
-                '{% block internal_header_stylesheets %}' . PHP_EOL .
-                '{{ parent() }}' . PHP_EOL .
-                '<style>.foo{bar}</style>' . PHP_EOL .
-                '{% endblock %}' . PHP_EOL . PHP_EOL .
-                '{% block internal_header_javascripts %}' . PHP_EOL .
-                '{{ parent() }}' . PHP_EOL .
-                '<script>$(document).ready(function () {foo(bar){}});</script>' . PHP_EOL .
-                '{% endblock %}' . PHP_EOL . PHP_EOL,
-                array('asset.css'),
-                '.foo{bar}',
-                array('stylesheets.js'),                
-                'foo(bar){}',
-            ),
-            array(
-                false,
-                 PHP_EOL . '{#--------------  ASSETS SECTION  --------------#}' . PHP_EOL .
-                '{% block external_stylesheets %}' . PHP_EOL .
-                '{{ parent() }}' . PHP_EOL .
-                '  {% stylesheets "asset.css" filter="?cssrewrite" %}' . PHP_EOL .
+                '  {% stylesheets "asset.css" filter="cssrewrite" %}' . PHP_EOL .
                 '    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />' . PHP_EOL .
                 '  {% endstylesheets %}' . PHP_EOL .
                 '{% endblock %}' . PHP_EOL . PHP_EOL .                

--- a/Tests/Unit/Core/Deploy/TemplateSection/TemplateSectionTwigTest.php
+++ b/Tests/Unit/Core/Deploy/TemplateSection/TemplateSectionTwigTest.php
@@ -202,9 +202,9 @@ class TemplateSectionTwigTest extends TestCase
                 'stylesheets',
                 'file1.css file2.css',
                 '<link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />',
-                '?yui_css,cssrewrite',
+                'cssrewrite',
                 null,
-                '  {% stylesheets file1.css file2.css filter="?yui_css,cssrewrite" %}' . PHP_EOL .
+                '  {% stylesheets file1.css file2.css filter="cssrewrite" %}' . PHP_EOL .
                 '    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />' . PHP_EOL .
                 '  {% endstylesheets %}'
             ),
@@ -212,9 +212,9 @@ class TemplateSectionTwigTest extends TestCase
                 'stylesheets',
                 'file1.css file2.css',
                 '<link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />',
-                '?yui_css,cssrewrite',
+                'cssrewrite',
                 'style.css',
-                '  {% stylesheets file1.css file2.css filter="?yui_css,cssrewrite" output="style.css" %}' . PHP_EOL .
+                '  {% stylesheets file1.css file2.css filter="cssrewrite" output="style.css" %}' . PHP_EOL .
                 '    <link href="{{ asset_url }}" rel="stylesheet" type="text/css" media="all" />' . PHP_EOL .
                 '  {% endstylesheets %}'
             ),

--- a/Tests/Unit/DependencyInjection/RedKiteCmsExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/RedKiteCmsExtensionTest.php
@@ -36,7 +36,6 @@ class RedKiteCmsExtensionTest extends TestCase
         $this->assertEquals('%kernel.root_dir%/../%red_kite_cms.web_folder%', $this->container->getParameter('red_kite_cms.web_folder_full_path'));
         $this->assertEquals(array('en' => 'English', 'it' => 'Italian',), $this->container->getParameter('red_kite_cms.available_languages'));
         $this->assertEquals('uploads/assets', $this->container->getParameter('red_kite_cms.upload_assets_dir'));
-        $this->assertFalse($this->container->getParameter('red_kite_cms.enable_yui_compressor'));
         $this->assertEquals('Resources', $this->container->getParameter('red_kite_cms.deploy_bundle.resources_dir'));
         $this->assertEquals('%red_kite_cms.deploy_bundle.resources_dir%/config', $this->container->getParameter('red_kite_cms.deploy_bundle.config_dir'));
         $this->assertEquals('%red_kite_cms.deploy_bundle.resources_dir%/views', $this->container->getParameter('red_kite_cms.deploy_bundle.views_dir'));
@@ -72,11 +71,6 @@ class RedKiteCmsExtensionTest extends TestCase
     public function testUploadAssetsDir()
     {
         $this->scalarNodeParameter('red_kite_cms.upload_assets_dir', 'upload_assets_dir', 'new/upload/path');
-    }
-
-    public function testEnableYuiCompressor()
-    {
-        $this->scalarNodeParameter('red_kite_cms.enable_yui_compressor', 'enable_yui_compressor', true);
     }
 
     public function testDeployResourcesDir()


### PR DESCRIPTION
Remove `enable_yui_compressor` as a option since this can be handled by using `assetic` configuration like:

```
assetic:
    # java: "/usr/bin/java"
    filters:
        yui_css:
            jar: "%kernel.root_dir%/Resources/java/yuicompressor.jar"
            apply_to: "\.css$"
        yui_js:
            jar: "%kernel.root_dir%/Resources/java/yuicompressor.jar"
            apply_to: "\.js$"
```

This should be a better way and reduce some template and configuration code.
