### PR TITLE
Add more than one accordion or slider on the same page

### DIFF
--- a/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/Accordion/2.x/accordion.html.twig
+++ b/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/Accordion/2.x/accordion.html.twig
@@ -1,7 +1,7 @@
 {% extends "RedKiteCmsBundle:Block:Editor/_editor.html.twig" %}
 
 {% block body %}
-<div class="accordion al-accordion-list inline-list" id="al-accordion" {{ editor|raw }}>
+<div class="accordion al-accordion-list inline-list" id="al-accordion-{{ block_manager.get.getId }}" {{ editor|raw }}>
     {% for key, item in items %}
     {% set baseSlotName = block_manager.get.getId ~ "-" ~ key %} 
     {% set attributes = 'data-item=' ~ key ~ ' data-slot-name=' ~ baseSlotName %}

--- a/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/Accordion/3.x/accordion.html.twig
+++ b/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/Accordion/3.x/accordion.html.twig
@@ -1,7 +1,7 @@
 {% extends "RedKiteCmsBundle:Block:Editor/_editor.html.twig" %}
 
 {% block body %}
-<div class="panel-group al-accordion-list inline-list" id="al-accordion" {{ editor|raw }}>
+<div class="panel-group al-accordion-list inline-list" id="al-accordion-{{ block_manager.get.getId }}" {{ editor|raw }}>
     {% for key, item in items %}
     {% set baseSlotName = block_manager.get.getId ~ "-" ~ key %} 
     {% set attributes = 'data-item=' ~ key ~ ' data-slot-name=' ~ baseSlotName %}

--- a/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/AccordionPanel/2.x/accordion_panel.html.twig
+++ b/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/AccordionPanel/2.x/accordion_panel.html.twig
@@ -9,13 +9,13 @@
 <div class="accordion-group" {{ editor|raw }} data-hide-blocks-menu="true">
     <div class="accordion-heading">
         <h4>
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#al-accordion" href="#item{{ key }}">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#al-accordion-{{ parent_block_id }}" href="#item-{{ parent_block_id }}-{{ key }}">
                 {% set blockSlotName = baseSlotName ~ "-0" %}  
                 {{ renderIncludedBlock(blockSlotName, block_manager, "Text", true, '', 'data-hide-blocks-menu=true') }}
             </a>
         </h4>
     </div>
-    <div id="item{{ key }}" class="accordion-body collapse{% if key == 0 %} in{% endif %}">
+    <div id="item-{{ parent_block_id }}-{{ key }}" class="accordion-body collapse{% if key == 0 %} in{% endif %}">
         <div class="accordion-inner">
             {% set blockSlotName = baseSlotName ~ "-1" %}  
             {{ renderIncludedBlock(blockSlotName, block_manager, "Text", true, '', 'data-hide-blocks-menu=true') }}

--- a/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/AccordionPanel/3.x/accordion_panel.html.twig
+++ b/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/AccordionPanel/3.x/accordion_panel.html.twig
@@ -9,13 +9,13 @@
 <div class="panel panel-default" {{ editor|raw }} data-hide-blocks-menu="true">
     <div class="panel-heading">
         <h4 class="panel-title">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#al-accordion" href="#item{{ key }}">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#al-accordion-{{ parent_block_id }}" href="#item-{{ parent_block_id }}-{{ key }}">
                 {% set blockSlotName = baseSlotName ~ "-0" %}  
                 {{ renderIncludedBlock(blockSlotName, block_manager, "Text", true, '', 'data-hide-blocks-menu=true') }}
             </a>
         </h4>
     </div>
-    <div id="item{{ key }}" class="panel-collapse collapse {% if key == 0 %} in{% endif %}">
+    <div id="item-{{ parent_block_id }}-{{ key }}" class="panel-collapse collapse {% if key == 0 %} in{% endif %}">
         <div class="panel-body">
             {% set blockSlotName = baseSlotName ~ "-1" %}  
             {{ renderIncludedBlock(blockSlotName, block_manager, "Text", true, '', 'data-hide-blocks-menu=true') }}

--- a/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/Slider/3.x/content.html.twig
+++ b/src/RedKiteCms/Block/TwitterBootstrapBundle/Resources/views/Content/Slider/3.x/content.html.twig
@@ -1,7 +1,7 @@
 {% extends "RedKiteCmsBundle:Block:Editor/_editor.html.twig" %}
 
 {% if carousel_id is not defined or carousel_id == "" %}
-{% set carousel_id = "rk-carousel" %}
+{% set carousel_id = "rk-carousel-" ~ block_manager.get.getId %}
 {% endif %}
 
 {% block body %}

--- a/src/RedKiteLabs/RedKiteCms/RedKiteCmsBundle/Tests/Functional/Controller/BlocksControllerTest.php
+++ b/src/RedKiteLabs/RedKiteCms/RedKiteCmsBundle/Tests/Functional/Controller/BlocksControllerTest.php
@@ -48,7 +48,7 @@ class BlocksControllerTest extends WebTestCaseFunctional
      * @dataProvider addFailsProvider
      */
     public function testAddBlockFails($params, $message)
-    {//print_R($params);
+    {
         $crawler = $this->browse('/backend/en/addBlock', $params);
         $this->assertRegExp(
             $message,

--- a/src/RedKiteLabs/RedKiteCms/RedKiteCmsBundle/Twig/SlotRendererExtension.php
+++ b/src/RedKiteLabs/RedKiteCms/RedKiteCmsBundle/Twig/SlotRendererExtension.php
@@ -116,16 +116,16 @@ class SlotRendererExtension extends \Twig_Extension
                 $hideInEditMode = (array_key_exists('HideInEditMode', $block) && $block['HideInEditMode']) ? 'true' : 'false';
                 $editorParameters = $blockManager->editorParameters();
                 $cmsAttributes = $templating->render('RedKiteCmsBundle:Block:Editor/_editable_block_attributes.html.twig', array(
-                    'block_id' => $block['Block']["Id"],
-                    'hide_in_edit_mode' => $hideInEditMode,
-                    'slot_name' => $slotName,
-                    'type' => $block['Block']['Type'],
-                    'content' => $content,
-                    'edit_inline' => $block['EditInline'],
-                    'editor' => $editorParameters,
-                    'extra_attributes' => $extraAttributes,
-                    'included' => $included,
-                ));
+                        'block_id' => $block['Block']["Id"],
+                        'hide_in_edit_mode' => $hideInEditMode,
+                        'slot_name' => $slotName,
+                        'type' => $block['Block']['Type'],
+                        'content' => $content,
+                        'edit_inline' => $block['EditInline'],
+                        'editor' => $editorParameters,
+                        'extra_attributes' => $extraAttributes,
+                        'included' => $included,
+                    ));
 
                 if (preg_match('/data\-encoded\-content=\'(.*?)\'/s', $cmsAttributes, $matches)) {
                     $cmsAttributes = preg_replace('/data\-encoded\-content=\'(.*?)\'/s', 'data-encoded-content=\'' . rawurlencode($matches[1]) . '\'', $cmsAttributes);
@@ -135,12 +135,12 @@ class SlotRendererExtension extends \Twig_Extension
             }
 
             return $templating->render('RedKiteCmsBundle:Slot:Page/' . $template, array(
-                'block_id' => $block['Block']["Id"],
-                'slot_name' => $slotName,
-                'type' => $block['Block']['Type'],
-                'content' => $content,
-                'edit_inline' => $block['EditInline'],
-            ));
+                    'block_id' => $block['Block']["Id"],
+                    'slot_name' => $slotName,
+                    'type' => $block['Block']['Type'],
+                    'content' => $content,
+                    'edit_inline' => $block['EditInline'],
+                ));
         } catch (\Exception $ex) {
             throw $ex;
         }
@@ -177,17 +177,17 @@ class SlotRendererExtension extends \Twig_Extension
     {
         return array(
             'renderSlot' => new \Twig_Function_Method($this, 'renderSlot', array(
-                'is_safe' => array('html'),
-            )),
+                    'is_safe' => array('html'),
+                )),
             'renderBlock' => new \Twig_Function_Method($this, 'renderBlock', array(
-                'is_safe' => array('html'),
-            )),
+                    'is_safe' => array('html'),
+                )),
             'blockContentToHtml' => new \Twig_Function_Method($this, 'blockContentToHtml', array(
-                'is_safe' => array('html'),
-            )),
+                    'is_safe' => array('html'),
+                )),
             'renderIncludedBlock' => new \Twig_Function_Method($this, 'renderIncludedBlock', array(
-                'is_safe' => array('html'),
-            )),
+                    'is_safe' => array('html'),
+                )),
         );
     }
 
@@ -198,8 +198,9 @@ class SlotRendererExtension extends \Twig_Extension
         $blocks = $repository->retrieveContents(null,  null, $key);
         $blockManagerFactory = $this->container->get('red_kite_cms.block_manager_factory');
 
-        $extraOptions = array('parent_slot_name' => $key); //array_merge(array('parent_slot_name' => $key), $extraOptions);
+        $extraOptions = array('parent_slot_name' => $key);
         if (null !== $parent && preg_match('/' . $parent->get()->getId() .  '\-([0-9]+)/', $key, $matches)) {
+            $extraOptions['parent_block_id'] = $parent->get()->getId();
             $extraOptions['key'] = $matches[1];
         }
 
@@ -216,7 +217,7 @@ class SlotRendererExtension extends \Twig_Extension
 
                 return $this->renderBlock($blockManager, '_included_block.html.twig', true, $editorExtraAttributes, $extraOptions);
             }
-        // @codeCoverageIgnoreStart
+            // @codeCoverageIgnoreStart
         }
         // @codeCoverageIgnoreEnd
 
@@ -232,11 +233,11 @@ class SlotRendererExtension extends \Twig_Extension
                 $parentBlock = $parent->get();
 
                 $values = array(
-                  "PageId"          => $parentBlock->getPageId(),
-                  "LanguageId"      => $parentBlock->getLanguageId(),
-                  "SlotName"        => $key,
-                  "Type"            => $type,
-                  "ContentPosition" => 1,
+                    "PageId"          => $parentBlock->getPageId(),
+                    "LanguageId"      => $parentBlock->getLanguageId(),
+                    "SlotName"        => $key,
+                    "Type"            => $type,
+                    "ContentPosition" => 1,
                 );
 
                 if ( ! empty($defaultContent)) {
@@ -247,7 +248,7 @@ class SlotRendererExtension extends \Twig_Extension
 
                 return $this->renderBlock($blockManager, '_included_block.html.twig', true, $editorExtraAttributes, $extraOptions);
             }
-        // @codeCoverageIgnoreStart
+            // @codeCoverageIgnoreStart
         }
         // @codeCoverageIgnoreEnd
         return sprintf('<div data-editor="enabled" data-block-id="0" data-slot-name="%s" data-included="1">%s</div>', $key, $this->translator->translate('twig_extension_empty_slot', array(), 'RedKiteCmsBundle'));


### PR DESCRIPTION
This PR updates the SlotRendererExtension to pass to the rendering block the parent's block id. This information is used, at the moment, by the accordion and slider blocks to create an unique element on page so user can add more than one block on the same page
