### PR TITLE
Implemented missing class tag

### DIFF
--- a/src/RedKiteCms/Block/RedKiteCmsBaseBlocksBundle/Resources/views/Content/Link/link.html.twig
+++ b/src/RedKiteCms/Block/RedKiteCmsBaseBlocksBundle/Resources/views/Content/Link/link.html.twig
@@ -3,7 +3,7 @@
 {% block body %}
 
 {% if wrapper_tag is defined %}
-<{{ wrapper_tag }} {{ editor|raw }} {% if(active_page is defined and link.href == active_page) %} class="active"{% endif %}{% if item is defined %} data-item="{{ item }}"{% endif %}{% if slot_name is defined %} data-slot-name="{{ slot_name }}"{% endif %}>
+<{{ wrapper_tag }} {{ editor|raw }} class="{% if(active_page is defined and link.href == active_page) %}active {% endif %}{% if link.class is defined %}{{ link.class }}{% endif %}" {% if item is defined %} data-item="{{ item }}"{% endif %}{% if slot_name is defined %} data-slot-name="{{ slot_name }}"{% endif %}>
 {% if no_link_when_active is defined and active_page is defined and no_link_when_active and link.href == active_page %}
 <span>{{ link.value }}</span>
 {% else %}


### PR DESCRIPTION
It seems that the `class` attribute on `Link` items is not implemented in the template.
