### PR TITLE
Fix collision issue in al-inline-list.js

### DIFF
--- a/src/RedKiteLabs/RedKiteCms/RedKiteCmsBundle/Resources/public/js/al-inline-list.js
+++ b/src/RedKiteLabs/RedKiteCms/RedKiteCmsBundle/Resources/public/js/al-inline-list.js
@@ -117,7 +117,7 @@
                     my: "center top",
                     at: settings.position,
                     of: $this,
-                    collision: 'fit fit'
+                    collision: 'none none'
                 })
                 .addClass('inline-list-commands-container')
                 .css('position', 'absolute')


### PR DESCRIPTION
Changed the collision parameters from 'fit fit' to 'none none' to fix issue of add and delete button containers not being positioned correctly for list elements that are not in the browser window. The 'fit' option causes the button container to be placed at the bottom of the browser window for all list elements that are not within the viewable browser window. The offscreen element's add/delete button containers are usually 'stacked' behind each other as they all end up with the same y position.
